### PR TITLE
feat: Add error handling and toast notifications

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,8 @@
         "react-i18next": "^15.4.1",
         "react-icons": "^5.5.0",
         "react-router-dom": "^7.2.0",
-        "recharts": "^2.15.1"
+        "recharts": "^2.15.1",
+        "sonner": "^2.0.6"
       },
       "devDependencies": {
         "@eslint/js": "^9.19.0",
@@ -5117,6 +5118,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.6.tgz",
+      "integrity": "sha512-yHFhk8T/DK3YxjFQXIrcHT1rGEeTLliVzWbO0xN8GberVun2RiBnxAjXAYpZrqwEVHBG9asI/Li8TAAhN9m59Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map-js": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "react-i18next": "^15.4.1",
     "react-icons": "^5.5.0",
     "react-router-dom": "^7.2.0",
-    "recharts": "^2.15.1"
+    "recharts": "^2.15.1",
+    "sonner": "^2.0.6"
   },
   "devDependencies": {
     "@eslint/js": "^9.19.0",

--- a/src/components/chatbot.tsx
+++ b/src/components/chatbot.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 import { FaTimes } from "react-icons/fa";
 import "./chatbot.css";
+import { handleError } from "../utils/errorHandlerToast";
 
 const Chatbot: React.FC<{ onClose: () => void }> = ({ onClose }) => {
   const [messages, setMessages] = useState<
@@ -49,6 +50,7 @@ const Chatbot: React.FC<{ onClose: () => void }> = ({ onClose }) => {
       }
     } catch (error) {
       setMessages((prev) => [...prev, { text: "Request failed", type: "bot" }]);
+      handleError(error)
     }
   };
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,6 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import { Toaster } from "sonner"
 // bootstrap
 import "bootstrap/dist/css/bootstrap.min.css";
 import "bootstrap/dist/js/bootstrap.bundle.min";
@@ -9,5 +10,6 @@ import App from "./App.js";
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <App />
+    <Toaster richColors closeButton position="top-center" />
   </StrictMode>
 );

--- a/src/pages/Admin/Add.tsx
+++ b/src/pages/Admin/Add.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { Modal, Button, Form } from "react-bootstrap";
 import axios from "axios";
+import { handleError } from "../../utils/errorHandlerToast";
 
 interface PropertyFormProps {
   show: boolean;
@@ -69,7 +70,7 @@ const PropertyForm: React.FC<PropertyFormProps> = ({
       refreshProperties(); // Refresh Dashboard
       handleClose();
     } catch (error) {
-      console.error("Error adding property:", error);
+      handleError(error)
     }
   };
 

--- a/src/pages/Admin/admin.tsx
+++ b/src/pages/Admin/admin.tsx
@@ -5,6 +5,7 @@ import "./admin.css"; // Custom styles
 import "bootstrap-icons/font/bootstrap-icons.css";
 import PropertyForm from "./Add"; // Import the PropertyForm component
 import axios from "axios";
+import { handleError } from "../../utils/errorHandlerToast";
 
 const Dashboard: React.FC = () => {
   const [sidebarOpen, setSidebarOpen] = useState(false);
@@ -21,7 +22,7 @@ const Dashboard: React.FC = () => {
       const response = await axios.get("http://localhost:5000/api/properties");
       setProperties(response.data);
     } catch (error) {
-      console.error("Error fetching properties:", error);
+      handleError(error, "Error occured while fetching properties.")
     }
   };
 

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -1,6 +1,8 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, FormEvent } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import "bootstrap/dist/css/bootstrap.min.css";
+import { handleError } from "../utils/errorHandlerToast";
+import { showError, showSuccess } from "../utils/toastUtils";
 
 function Auth() {
   const location = useLocation();
@@ -18,11 +20,11 @@ function Auth() {
     }
   }, [location]);
 
-  const handleSubmit = async (event) => {
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     
     if (!isLogin && password !== confirmPassword) {
-      alert("Passwords do not match!");
+      showError("Passwords do not match!");
       return;
     }
 
@@ -42,14 +44,14 @@ function Auth() {
       
       const data = await response.json();
       if (response.ok) {
-        console.log(isLogin ? "Login Successful" : "Signup Successful", data);
+        showSuccess(isLogin ? "Login Successful" : "Signup Successful");
+        console.log(data);
         navigate("/places");
       } else {
-        alert(data.message || "An error occurred");
+        showError(data.message || "An error occurred");
       }
     } catch (error) {
-      console.error("Error:", error);
-      alert("Network error, please try again.");
+      handleError(error, "Network error, please try again.");
     }
   };
 

--- a/src/utils/errorHandlerToast.ts
+++ b/src/utils/errorHandlerToast.ts
@@ -1,0 +1,30 @@
+import { toast } from "sonner";
+
+/**
+ * Handles and displays error messages using toast notifications.
+ *
+ * - If the error is a standard `Error` instance, it displays the `.message` property.
+ * - If the error is an object (e.g., Axios or Fetch error), it attempts to read a `message` field.
+ * - If the error is unknown or invalid, a fallback message is shown.
+ *
+ * All errors are also logged to the console for debugging.
+ *
+ * @param {unknown} error - The error object to handle. Can be of any type.
+ * @param {string} [fallbackMessage="Something went wrong"] - A default message used when no specific error message is available.
+ */
+export function handleError(error?: unknown, fallbackMessage: string = "Something went wrong") {
+    if(error instanceof Error) {
+        toast.error(error.message || fallbackMessage)
+    }
+
+    if(typeof error === "object" && error !== null) {
+        const err = error as Record<string,any>;
+        toast.error(err.message || fallbackMessage)
+    }
+
+    else {
+        toast.error(fallbackMessage);
+    }
+
+    console.log("Handled error: ",error);
+}

--- a/src/utils/toastUtils.ts
+++ b/src/utils/toastUtils.ts
@@ -1,0 +1,68 @@
+import { toast } from "sonner";
+
+/**
+ * Displays a success toast notification with the provided message.
+ *
+ * @param {string} message - The success message to show.
+ */
+export const showSuccess = (message: string) => {
+  toast.success(message);
+};
+
+/**
+ * Displays an error toast notification with the provided message.
+ *
+ * @param {string} message - The error message to show.
+ */
+export const showError = (message: string) => {
+  toast.error(message);
+};
+
+/**
+ * Displays a warning toast notification with the provided message.
+ *
+ * @param {string} message - The warning message to show.
+ */
+export const showWarning = (message: string) => {
+  toast.warning(message);
+};
+
+/**
+ * Displays a default/info toast notification with the provided message.
+ *
+ * @param {string} message - The informational message to show.
+ */
+export const showInfo = (message: string) => {
+  toast.info(message);
+};
+
+/**
+ * Displays a loading toast and returns its ID.
+ *
+ * You can use the returned ID to later dismiss or update the toast.
+ *
+ * @param {string} message - The message to show while loading.
+ * @returns {string | number} The toast ID for dismissal or update.
+ *
+ * @example
+ * const toastId = showLoading("Uploading file...");
+ */
+export const showLoading = (message: string) => {
+  return toast.loading(message);
+};
+
+/**
+ * Dismisses a toast by its ID.
+ *
+ * Useful for removing a loading toast after the operation is complete.
+ *
+ * @param {string | number} toastId - The ID of the toast to dismiss.
+ *
+ * @example
+ * const id = showLoading("Processing...");
+ * // Later
+ * dismissToast(id);
+ */
+export const dismissToast = (toastId: string | number) => {
+  toast.dismiss(toastId);
+};


### PR DESCRIPTION
Fixes: #8 

### **Description**

This PR enhances the user experience by replacing native `alert()` popups with modern toast notifications using the sonner library. Additionally, it introduces a robust utility function to handle `try/catch` errors.

### **What's included**

- Replaced all `alert()` calls with non-intrusive toasts (sonner).

- Introduced toastUtils.ts: a centralized utility with reusable functions for `success`, `error`, `warning`, `info`, `loading` + `dismissToast`

- Created `handleError(error, fallbackMessage)` which handles unknown error types (`Error`, `AxiosError`, `strings`, etc.)

-  All toast functions are cleanly and neatly documented with the help of `JSDoc` comments (` /** */ `)

- Displays a fallback toast message when the error object isn't informative.

- Promotes cleaner and DRY `try/catch` blocks across the app.

### **Preview**
Preview of an error toast generated using `handleError()` function: 
<img width="1901" height="968" alt="image" src="https://github.com/user-attachments/assets/aee2cdcd-2a0a-4399-ab6f-c9e02b77bc0a" />

### **Implemented**

- [x] Replaced all `alerts()` with toast util functions.

- [x] Integrated a toast notification library (sonner).

- [x] Created a reusable error handler function for triggering toasts.

- [x] Catched and surfaced server/API errors gracefully using this handler.

- [x] Tested across common failure points (form submissions, API failures, etc.).

### **How to Test**
1. Perform an action that could result in an error (e.g. failed fetch, invalid form).
2. Confirm that a toast notification appears instead of a native alert.
3. If the error is known (e.g., server message), it’s displayed; otherwise, the fallback message is shown.

Hey @Richajaishwal0 Let me know if you'd like me to tweak the toast styles, durations, or positions. Happy to iterate on this.