### PR TITLE
fix: fixed duplicate package.json entries to resolve npm install error in backend (server )

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -25,25 +25,3 @@
     "nodemon": "^3.0.1"
   }
 }
-{
-  "name": "server",
-  "version": "1.0.0",
-  "main": "server.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node server.js"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
-  "description": "",
-  "dependencies": {
-    "cors": "^2.8.5",
-    "dotenv": "^17.2.1",
-    "express": "^5.1.0",
-    "mongoose": "^8.16.5",
-    "multer": "^2.0.2",
-    "mysql2": "^3.14.2",
-    "path": "^0.12.7"
-  }
-}


### PR DESCRIPTION
While installing backend dependencies in the server folder, npm install failed with the following error:

npm ERR! JSON.parse Unexpected non-whitespace character after JSON...
npm ERR! JSON.parse Failed to parse JSON data.


This was caused by having two separate JSON objects inside package.json, which is invalid JSON.