### PR TITLE
Fix footer social links  #139

### DIFF
--- a/client/src/components/footer.tsx
+++ b/client/src/components/footer.tsx
@@ -375,7 +375,8 @@ const Footer: React.FC = () => {
               </div>
               <div className="col-md-5 col-lg-4 text-start">
                 <a
-                  href="#"
+                  href="https://facebook.com/"
+                  target="_blank"
                   className="btn m-1 text-white"
                   role="button"
                   style={{
@@ -407,7 +408,8 @@ const Footer: React.FC = () => {
                   <FaFacebookF size={16} />
                 </a>
                 <a
-                  href="#"
+                  href="https://x.com/"
+                  target="_blank"
                   className="btn m-1 text-white"
                   role="button"
                   style={{
@@ -439,7 +441,8 @@ const Footer: React.FC = () => {
                   <FaTwitter size={16} />
                 </a>
                 <a
-                  href="#"
+                  href="https://google.com/"
+                  target="_blank"
                   className="btn m-1 text-white"
                   role="button"
                   style={{
@@ -471,7 +474,8 @@ const Footer: React.FC = () => {
                   <FaGoogle size={16} />
                 </a>
                 <a
-                  href="#"
+                  href="https://instagram.com/"
+                  target="_blank"
                   className="btn m-1 text-white"
                   role="button"
                   style={{


### PR DESCRIPTION
Closes #139

What does this PR do?
This PR fixes the social media icons in the website footer, which were not linked correctly. The icons for Facebook, Twitter, Google, and Instagram now redirect to their respective websites and open in a new tab for a better user experience.

Changes Made
In client/src/components/footer.tsx, updated the href="#" attribute for each social media icon with the correct URL.

Added target="_blank" to each <a> tag to open the links in a new tab.

Code Diff (Before vs. After)

Before:
<a href="#" className="btn m-1 text-white" ...>
  <FaFacebookF size={16} />
</a>
<a href="#" className="btn m-1 text-white" ...>
  <FaTwitter size={16} />
</a>
// ... and so on for Google and Instagram

After:
<a href="https://facebook.com/" target="_blank"  className="btn m-1 text-white" ...>
  <FaFacebookF size={16} />
</a>
<a href="https://x.com/" target="_blank"  className="btn m-1 text-white" ...>
  <FaTwitter size={16} />
</a>
.........


Proof of Work
A screen recording showing the updated links working as expected.
https://github.com/user-attachments/assets/6abf01fb-638a-4d04-914a-a85a4b8678d6


Testing
Navigate to the bottom of any page to view the footer.
Click on each social media icon (Facebook, Twitter, Google, Instagram).
Tested on Chrome, Firefox, and Brave