### PR TITLE
Remove react-leaflet-cluster to fix compatibility (Fixes #172)

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -21,7 +21,6 @@
         "react-dom": "^19.0.0",
         "react-icons": "^5.5.0",
         "react-leaflet": "^5.0.0",
-        "react-leaflet-cluster": "^3.1.1",
         "react-router-dom": "^7.2.0",
         "sonner": "^2.0.6"
       },
@@ -390,6 +389,31 @@
         "react-dom": "^18.0.0"
       }
     },
+    "node_modules/@changey/react-leaflet-markercluster/node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@changey/react-leaflet-markercluster/node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
     "node_modules/@changey/react-leaflet-markercluster/node_modules/react-leaflet": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-4.2.1.tgz",
@@ -402,6 +426,15 @@
         "leaflet": "^1.9.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@changey/react-leaflet-markercluster/node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -4342,21 +4375,6 @@
         "leaflet": "^1.9.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
-      }
-    },
-    "node_modules/react-leaflet-cluster": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/react-leaflet-cluster/-/react-leaflet-cluster-3.1.1.tgz",
-      "integrity": "sha512-g39QohKNrmIwHNlL0KTv+a9PYYWDtcRAsnHHytJyRhIgjxGxs4/SXe/Zr4kP8IZoEzxbqCMkJqUsFBEZJqKp2g==",
-      "license": "SEE LICENSE IN <LICENSE>",
-      "dependencies": {
-        "leaflet.markercluster": "^1.5.3"
-      },
-      "peerDependencies": {
-        "leaflet": "^1.8.0",
-        "react": "^18.2.0 || ^19.0.0",
-        "react-dom": "^18.2.0 || ^19.0.0",
-        "react-leaflet": "^4.0.0"
       }
     },
     "node_modules/react-lifecycles-compat": {

--- a/client/package.json
+++ b/client/package.json
@@ -22,7 +22,6 @@
     "react-dom": "^19.0.0",
     "react-icons": "^5.5.0",
     "react-leaflet": "^5.0.0",
-    "react-leaflet-cluster": "^3.1.1",
     "react-router-dom": "^7.2.0",
     "sonner": "^2.0.6"
   },


### PR DESCRIPTION
This PR removes the react-leaflet-cluster package from the project due to compatibility issues with react-leaflet@5.x. Removing this package prevents dependency conflicts and ensures that the application runs smoothly without runtime errors related to clustering.

Fixes #172

✅ Type of Change

 🐛 Bug fix